### PR TITLE
Update BestieTemplate.jl URL to JuliaBesties

### DIFF
--- a/docs/paul/bestpractices.html
+++ b/docs/paul/bestpractices.html
@@ -536,7 +536,7 @@ Paul Schrimpf
 <li>Setup your package with a project skeleton
 <ul>
 <li><a href="https://github.com/JuliaCI/PkgTemplates.jl"><code>PkgTemplates.jl</code></a></li>
-<li><a href="https://github.com/abelsiqueira/BestieTemplate.jl"><code>BestieTemplate.jl</code></a></li>
+<li><a href="https://github.com/JuliaBesties/BestieTemplate.jl"><code>BestieTemplate.jl</code></a></li>
 <li><a href="https://juliadynamics.github.io/DrWatson.jl/stable/"><code>DoctorWatson.jl</code></a></li>
 <li><span class="citation" data-cites="haider2021">Haider, Riesch, and Jirauschek (<a href="#/references" role="doc-biblioref" onclick="">2021</a>)</span> for similar idea for other languages</li>
 </ul></li>

--- a/qmd/bestpractices.qmd
+++ b/qmd/bestpractices.qmd
@@ -88,7 +88,7 @@ $$
 - Good advice aimed at scientific computing projects: [Julia: Project Workflow](https://j-fu.github.io/marginalia/julia/project-workflow/)
 - Setup your package with a project skeleton
   - [`PkgTemplates.jl`](https://github.com/JuliaCI/PkgTemplates.jl)
-  - [`BestieTemplate.jl`](https://github.com/abelsiqueira/BestieTemplate.jl)
+  - [`BestieTemplate.jl`](https://github.com/JuliaBesties/BestieTemplate.jl)
   - [`DoctorWatson.jl`](https://juliadynamics.github.io/DrWatson.jl/stable/)
   - @haider2021 for similar idea for other languages
 


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
